### PR TITLE
feat: added command to upgrade deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "commit": "git-cz",
     "commit:retry": "git-cz --retry",
     "commitmsg": "commitlint -e",
-    "commitlint-circle": "commitlint-circle"
+    "commitlint-circle": "commitlint-circle",
+    "upgrade-deps": "npx updtr"
   },
   "types": "dist/ts",
   "husky": {


### PR DESCRIPTION
`npm run upgrade-deps` runs updtr https://github.com/peerigon/updtr

does

1. upgrade to latest non-breaking

2. runs tests

3. upgrades remaining major updates and then tests iteratively stepwise